### PR TITLE
Remove jq install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Terraform
         run: |
           .github/setup-hashicorp-apt-repo.sh
-          sudo apt install terraform jq
+          sudo apt install terraform
       - name: Checkout Terraform state
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
jq is present in the GitHub Actions runner by default, so it does not have to be installed in the deploy workflow.