### PR TITLE
Replace `apt` usages with `apt-get`

### DIFF
--- a/.github/setup-hashicorp-apt-repo.sh
+++ b/.github/setup-hashicorp-apt-repo.sh
@@ -13,4 +13,4 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=${keyring_path}]" \
   "${source_url} $(lsb_release -cs) main" | sudo tee "${source_path}"
 
 # Update with repository
-sudo apt update
+sudo apt-get update

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Terraform
         run: |
           .github/setup-hashicorp-apt-repo.sh
-          sudo apt install terraform
+          sudo apt-get install terraform
       - name: Checkout Terraform state
         uses: actions/checkout@v4
         with:
@@ -65,8 +65,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Ansible
         run: |
-          sudo apt update
-          sudo apt install pipx
+          sudo apt-get update && sudo apt-get install pipx
           pipx install --include-deps ansible --force
           pipx inject ansible boto3
       - name: Setup SSH Access


### PR DESCRIPTION
`apt` warns of its absence of a stable CLI interface when used. Adhere to recommended shell scripting practice by using `apt-get` instead.